### PR TITLE
feat: '모지' 메시지 조회를 위한 API 연동

### DIFF
--- a/src/app/api/chat-direct/route.ts
+++ b/src/app/api/chat-direct/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const POST = async (request: NextRequest) => {
+    const openaiApiKey = process.env.OPENAI_API_KEY;
+    const openaiApiUrl = process.env.NEXT_PUBLIC_OPENAI_API_URL || 'https://api.openai.com/v1';
+
+    if (!openaiApiKey) {
+        return NextResponse.json({ error: 'OpenAI API key is not configured' }, { status: 500 });
+    }
+
+    try {
+        const { prompt, model = 'gpt-3.5-turbo' } = await request.json();
+
+        if (!prompt) {
+            return NextResponse.json({ error: 'Prompt is required' }, { status: 400 });
+        }
+
+        const response = await fetch(`${openaiApiUrl}/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${openaiApiKey}`,
+            },
+            body: JSON.stringify({
+                model: model,
+                messages: [
+                    {
+                        role: 'user',
+                        content: `너는 결단을 도와주는 조용하고 단단한 책 요정 '모지'야.
+                            사용자가 질문하지 않아도, 하루에 한 마디로 방향을 제시해줘.
+
+                            톤과 스타일은 다음과 같아:
+                            - 철학적이지만 실용적인 조언
+                            - 짧고 단호한 한 마디
+                            - 생각할 거리를 주는 말
+                            - 때로는 가볍게, 하지만 의미는 있어야 해
+
+                            말은 항상 **한 문장**, 짧고 강하게.
+                            절대 말장난이나 위로나 농담은 하지 마.  
+                            이건 결정을 밀어주는 메시지야.
+                            ~~다.로 끝나면 좋겠어
+
+                            말투는 직관적이고 자연스럽게. 어색한 문장 쓰지 마.`,
+                    },
+                ],
+            }),
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.json();
+            console.error('OpenAI API Error:', errorBody);
+            return NextResponse.json(
+                { error: 'Failed to fetch from OpenAI API', details: errorBody },
+                { status: response.status },
+            );
+        }
+
+        const data = await response.json();
+        return NextResponse.json(data);
+    } catch (error) {
+        console.error('API Route Error:', error);
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+};

--- a/src/app/hooks/api/useMojiMessage.ts
+++ b/src/app/hooks/api/useMojiMessage.ts
@@ -1,0 +1,16 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { mojiMessageQueryKey } from '@/utils/queryKeyFactory';
+import { getMojiMessage } from '@/remotes/chat-direct';
+
+const useMojiMessage = () => {
+    const { data: messages } = useSuspenseQuery(getMojiMessageQueryKeys());
+    return { messages };
+};
+
+const getMojiMessageQueryKeys = () =>
+    queryOptions<string>({
+        queryKey: mojiMessageQueryKey.base,
+        queryFn: () => getMojiMessage(),
+    });
+
+export default useMojiMessage;

--- a/src/models/chat-direct.ts
+++ b/src/models/chat-direct.ts
@@ -1,0 +1,7 @@
+export interface OpenAPI {
+    choices: Array<{
+        message: {
+            content: string;
+        };
+    }>;
+}

--- a/src/remotes/chat-direct.ts
+++ b/src/remotes/chat-direct.ts
@@ -1,0 +1,18 @@
+import { OpenAPI } from '@/models/chat-direct';
+import axios from 'axios';
+
+export const getMojiMessage = async (): Promise<string> => {
+    const { data } = await axios.post<OpenAPI>(
+        '/api/chat-direct',
+        {
+            prompt: '모지 응답!',
+        },
+        {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        },
+    );
+    const message = data.choices?.[0]?.message?.content || JSON.stringify(data);
+    return message;
+};

--- a/src/utils/queryKeyFactory.ts
+++ b/src/utils/queryKeyFactory.ts
@@ -1,3 +1,5 @@
 export const createQueryKeyFactory = <T extends string>(base: T) => ({
     base: [base] as const,
 });
+
+export const mojiMessageQueryKey = createQueryKeyFactory('moji-message');


### PR DESCRIPTION
- gpt API POST 라우트 추가
- '모지' 메시지 조회를 위한 커스텀 훅 및 API 연동 추가